### PR TITLE
Normalized React state

### DIFF
--- a/ui/src/types.ts
+++ b/ui/src/types.ts
@@ -9,3 +9,40 @@ export interface DriverLocation {
   id: string;
   mostRecentHeartbeat: string;
 }
+
+export interface NormalizedDriverLocations {
+  byId: { [key: string]: DriverLocation };
+  allIds: string[];
+}
+
+export function driverLocationsToState(
+  driverLocations: DriverLocation[]
+): NormalizedDriverLocations {
+  return {
+    allIds: driverLocations.map((dl) => dl.driverId),
+    byId: driverLocations.reduce((acc: any, dl: DriverLocation) => {
+      acc[dl.driverId] = dl;
+      return acc;
+    }, {}),
+  };
+}
+
+export function addDriverLocationToState(
+  s: NormalizedDriverLocations,
+  dl: DriverLocation
+): NormalizedDriverLocations {
+  // prevent double-add
+  if (s?.byId?.[dl.driverId]) {
+    return s;
+  }
+  return {
+    byId: { ...s.byId, [dl.driverId]: dl },
+    allIds: [...s.allIds, dl.driverId],
+  } as NormalizedDriverLocations;
+}
+
+export function getDriverLocationsFromState(
+  s: NormalizedDriverLocations
+): DriverLocation[] {
+  return Object.entries(s?.byId ?? []).map(([id, dl], i: number) => dl);
+}


### PR DESCRIPTION
There could be thousands of drivers on the map. Instead of using an array, use an object for constant-time access. This requires changing how we persist driver locations in React state. Lots of inspiration drawn from [here](https://redux.js.org/usage/structuring-reducers/normalizing-state-shape).

After this PR, we can do certain things efficiently:
- when a new driver is hovered over in the list, we can highlight its map marker
- when we hover over a locally cached driver's map marker, we can highlight its position in the "new drivers" list